### PR TITLE
kcidb.io_schema: allow "-" characters in test path

### DIFF
--- a/kcidb/io_schema.py
+++ b/kcidb/io_schema.py
@@ -278,7 +278,7 @@ JSON_TEST = {
                 "tree the executed test belongs to. E.g. \"LTPlite.sem01\". "
                 "The empty string, or the absence of the property signify "
                 "the root of the tree, i.e. an abstract test.",
-            "pattern": "^[.a-zA-Z0-9_]*$"
+            "pattern": "^[.a-zA-Z0-9_-]*$"
         },
         "description": {
             "type": "string",


### PR DESCRIPTION
Some test suites use dashes in test case names, so to avoid having to
mangle them and use their original names allow "-" dashes in the test
paths in the schema.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>